### PR TITLE
Allow floats as duration

### DIFF
--- a/lib/countdown.js
+++ b/lib/countdown.js
@@ -4,7 +4,7 @@
   var root = this;
 
   var Countdown = function(duration, onTick, onComplete) {
-    var secondsLeft = duration
+    var secondsLeft = Math.round(duration)
         , tick = function() {
           if (secondsLeft > 0) {
               onTick(secondsLeft);

--- a/test/test.js
+++ b/test/test.js
@@ -40,6 +40,28 @@ describe("countdown.js", function() {
       clock.tick(5000);
       assert(callbackFunction.callCount == 1);
     });
+
+    it("executes onComplete at 2 ticks for 2.4", function() {
+      new Countdown(2.4, tickFunction, callbackFunction);
+      clock.tick(1000);
+      assert(callbackFunction.callCount == 0);
+      clock.tick(1000);
+      assert(callbackFunction.callCount == 1);
+      // Ensure this is Math.round behavior
+      clock.tick(1000);
+      assert(callbackFunction.callCount == 1);
+    });
+
+    it("executes onComplete at 3 ticks for 2.5", function() {
+      new Countdown(2.5, tickFunction, callbackFunction);
+      clock.tick(1000);
+      assert(callbackFunction.callCount == 0);
+      clock.tick(1000);
+      assert(callbackFunction.callCount == 0);
+      // Ensure this is Math.round behavior
+      clock.tick(1000);
+      assert(callbackFunction.callCount == 1);
+    });
   });
 
   describe("aborting countdown", function() {


### PR DESCRIPTION
Another shot at https://github.com/gumroad/countdown.js/issues/4. This is extracted from this PR (https://github.com/gumroad/countdown.js/pull/7) and converts the duration instead as @kn had suggested.
